### PR TITLE
Disable AbstractSignEditScreenMixin when signedit mod is loaded

### DIFF
--- a/src/main/kotlin/ca/rttv/chatcalc/MixinConfigPlugin.kt
+++ b/src/main/kotlin/ca/rttv/chatcalc/MixinConfigPlugin.kt
@@ -1,0 +1,49 @@
+package ca.rttv.chatcalc
+
+import net.fabricmc.loader.api.FabricLoader
+import org.objectweb.asm.tree.ClassNode
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo
+import kotlin.text.contains
+
+class MixinConfigPlugin : IMixinConfigPlugin {
+    override fun onLoad(mixinPackage: String?) {
+    }
+
+    override fun getRefMapperConfig(): String? {
+        return null
+    }
+
+    override fun shouldApplyMixin(targetClassName: String?, mixinClassName: String?): Boolean {
+        if (mixinClassName!!.contains("AbstractSignEditScreenMixin")) {
+            return !FabricLoader.getInstance().isModLoaded("signedit")
+        }
+        return true
+    }
+
+    override fun acceptTargets(
+        myTargets: Set<String?>?,
+        otherTargets: Set<String?>?
+    ) {
+    }
+
+    override fun getMixins(): List<String?>? {
+        return mutableListOf()
+    }
+
+    override fun preApply(
+        targetClassName: String?,
+        targetClass: ClassNode?,
+        mixinClassName: String?,
+        mixinInfo: IMixinInfo?
+    ) {
+    }
+
+    override fun postApply(
+        targetClassName: String?,
+        targetClass: ClassNode?,
+        mixinClassName: String?,
+        mixinInfo: IMixinInfo?
+    ) {
+    }
+}

--- a/src/main/resources/chatcalc.mixins.json
+++ b/src/main/resources/chatcalc.mixins.json
@@ -3,6 +3,7 @@
 	"minVersion": "0.8",
 	"package": "ca.rttv.chatcalc.mixin",
 	"compatibilityLevel": "JAVA_21",
+	"plugin": "ca.rttv.chatcalc.MixinConfigPlugin",
 	"mixins": [ ],
 	"client": [
 		"ChatInputSuggesterMixin",


### PR DESCRIPTION
Note: this is an implemented suggestion, not a request per se, so do with it as you will.

This PR implements `IMixinConfigPlugin` to disable the `AbstractSignEditScreen` mixin when the [SignEdit](https://github.com/TerminalMC/SignEdit) mod is loaded, allowing a user to install and use both mods at the same time.